### PR TITLE
Fix animation output paths, params and quality arg annotation

### DIFF
--- a/04-Animations.ipynb
+++ b/04-Animations.ipynb
@@ -105,7 +105,7 @@
     "To create a video in **accessvis**, the best approach is to use the `lv.video()` context manager. Below are the key arguments you can use:\n",
     "\n",
     "- **filename**: Specifies the path and name of the video file to save.\n",
-    "- **quality**: Controls the quality of the video, with options ranging from 1 (low) to 4 (high), similar to the resolution selector.\n",
+    "- **quality**: Controls the quality of the video, with options ranging from 1 (low) to 3 (high), higher quality means less compression artifacts but a larger file\n",
     "- **resolution**: Sets the resolution of the saved video.\n",
     "- **framerate=30**: Defines the frames per second (FPS) for the video.\n",
     "- **params=\"autoplay\"**: If included, the video will be displayed within the notebook upon completion.\n",
@@ -274,10 +274,8 @@
     }
    ],
    "source": [
-    "filename = os.path.abspath('rotate_and_zoom.mp4')\n",
-    "print(filename)\n",
-    "\n",
-    "with lv.video(filename=filename, quality=4, resolution=(600,600), width=600, height=600, params=\"autoplay\") as v:\n",
+    "filename = 'rotate_and_zoom.mp4'\n",
+    "with lv.video(filename=filename, quality=1, resolution=(600,600), width=600, height=600) as v:\n",
     "    for lat, lon, h in tqdm(zip(latitudes, longitudes, heights), total=num_steps):\n",
     "        lv.reset() # Note that we must reset as rotate in this context gives a relative rotation.\n",
     "        lv.rotate('y',lat)\n",
@@ -438,8 +436,7 @@
     }
    ],
    "source": [
-    "filename = os.path.abspath('rotate_and_time_max_temp.mp4')\n",
-    "print(filename)\n",
+    "filename = 'rotate_and_time_max_temp.mp4'\n",
     "\n",
     "min_t = float(yearly_maximum.min())\n",
     "max_t = float(yearly_maximum.max())\n",
@@ -557,7 +554,7 @@
     }
    ],
    "source": [
-    "with lv.video(filename=filename, quality=4, resolution=(600,600), width=600, height=600, params=\"autoplay\") as v:\n",
+    "with lv.video(filename=filename, quality=2, resolution=(600,600), width=600, height=600) as v:\n",
     "    for year in tqdm(yearly_maximum.year.values):\n",
     "        data = yearly_maximum.sel(year=year)\n",
     "        colours = accessvis.array_to_rgba(data, colourmap=colourmap, minimum=min_t, maximum=max_t, flip=True)\n",
@@ -589,7 +586,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Removing abspath for filenames
Quality range is 1-3, best to leave lower for examples as creates larger files at higher quality
Default params are now "autoplay controls" so no need to pass autoplay and doing so without "controls" will remove the playback controls