### PR TITLE
Update conda environment references in setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ system at the National Computational Infrastructure (NCI), follow the steps belo
           ```
         - **Modules**: Add the environment:
           ```
-          conda/access-vis-0.3
+          conda/analysis3
           ```
 
 5. **Launch your JupyterLab session**:

--- a/docs/ARE_JupyterLab_setup_guide.md
+++ b/docs/ARE_JupyterLab_setup_guide.md
@@ -55,7 +55,7 @@ scratch/xp65+gdata/xp65...
 
 8. **Modules** To load the ESMValTool-workflow environment, please copy and paste the following. This is equivalent to using `module load` on the command line.
 ```
-conda/access-vis-0.3
+conda/analysis3
 ```
 
 <p align="center"><img src="assets_ARE/modules.png" alt="drawing" width="60%"/></p>


### PR DESCRIPTION
This pull request updates the documentation to reference the correct Conda environment module for JupyterLab sessions at NCI. The previous environment, `conda/access-vis-0.3`, is replaced with `conda/analysis3` to ensure users load the appropriate environment.

Documentation updates:

* Updated the module loading instructions in `README.md` to use `conda/analysis3` instead of `conda/access-vis-0.3`.
* Updated the module loading instructions in `docs/ARE_JupyterLab_setup_guide.md` to use `conda/analysis3` instead of `conda/access-vis-0.3`.